### PR TITLE
Allow user to seen other clients in a channel

### DIFF
--- a/ircstream/ircserver.py
+++ b/ircstream/ircserver.py
@@ -637,7 +637,10 @@ class IRCClient:
 
         nicklist: Iterable[str]
         if channel in self.channels:
-            nicklist = (self.nick, "@" + self.server.botname)
+            nicklist = [
+                "@" + self.server.botname,
+            ]
+            nicklist.extend([client.nick for client in self.server.clients(channel)])
         else:
             nicklist = ("@" + self.server.botname,)
 
@@ -815,6 +818,10 @@ class IRCServer:
     def unsubscribe(self, channel: str, client: IRCClient) -> None:
         """Unsubscribe a client from broadcasts for a particular channel."""
         self._channels[channel].remove(client)
+
+    def clients(self, channel: str) -> Iterable[IRCClient]:
+        """Return a list of all clients connected to a channel."""
+        return self._channels.get(channel, [])
 
     @property
     def channels(self) -> Iterable[str]:


### PR DESCRIPTION
To help identify bots, it is useful to be able to see their nicks. This patch does not prevent multiple clients from joining with the same nick, but given that messages can only be recieved and not sent, the nick duplication should not be an issue.